### PR TITLE
Bug 1777413: Avoid race between member addition and namespace deletion

### DIFF
--- a/kuryr_kubernetes/controller/handlers/lbaas.py
+++ b/kuryr_kubernetes/controller/handlers/lbaas.py
@@ -360,8 +360,14 @@ class LoadBalancerHandler(k8s_base.ResourceEventHandler):
                     # octavia does not require it
                     if (config.CONF.octavia_defaults.member_mode ==
                             k_const.OCTAVIA_L2_MEMBER_MODE):
-                        member_subnet_id = self._get_pod_subnet(target_ref,
-                                                                target_ip)
+                        try:
+                            member_subnet_id = self._get_pod_subnet(target_ref,
+                                                                    target_ip)
+                        except k_exc.K8sResourceNotFound:
+                            LOG.debug("Member namespace has been deleted. No "
+                                      "need to add the members as it is "
+                                      "going to be deleted")
+                            continue
                     else:
                         # We use the service subnet id so that the connectivity
                         # from VIP to pods happens in layer 3 mode, i.e.,


### PR DESCRIPTION
When a member is being added to the loadbalancer (as loadbalancer
creation may take some time) it may happen that the namespace
deletion action has been already triggered. This impact the L2 mode
as the members need to get their subnet from the kuryrnet crd object
if namespace subnet driver is being used. This patch handles that
exception and skips the member addition since there is no need to
add it if it is being deleted.